### PR TITLE
Remove optional data response from FinnhubClient

### DIFF
--- a/Examples/Stocks/ViewController.swift
+++ b/Examples/Stocks/ViewController.swift
@@ -16,96 +16,87 @@ class ViewController: UIViewController {
 
     func loadData() {
         /*
-          FinnhubClient.symbols(exchange: .unitedStates) { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.symbols(exchange: .unitedStates) { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.news(category: .general) { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.news(category: .general) { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.peers(symbol: "AAPL") { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.peers(symbol: "AAPL") { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.newsSentiment(symbol: "AAPL") { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.newsSentiment(symbol: "AAPL") { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.recommendations(symbol: "AAPL") { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.recommendations(symbol: "AAPL") { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.priceTarget(symbol: "AAPL") { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.priceTarget(symbol: "AAPL") { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
-          FinnhubClient.companyProfile2(symbol: "AAPL") { result in
-              switch result {
-              case let .success(data):
-                  print(data!)
-              case .failure(.invalidData):
-                  print("Invalid data")
-              case let .failure(.networkFailure(error)):
-                  print(error)
-              }
-          }
+         FinnhubClient.companyProfile2(symbol: "AAPL") { result in
+             switch result {
+             case let .success(data):
+                 print(data)
+             case .failure(.invalidData):
+                 print("Invalid data")
+             case let .failure(.networkFailure(error)):
+                 print(error)
+             }
+         }
 
          FinnhubLiveClient.shared.subscribe(symbol: "SQ")
          FinnhubLiveClient.shared.subscribe(symbols: ["AAPL", "TSLA", "AMZN", "SQ"])
          FinnhubLiveClient.shared.receiveMessage { result in
              switch result {
-             case let .failure(failure):
-                 switch failure {
-                 case .networkFailure:
-                     print(failure)
-                 case .invalidData:
-                     print("Invalid data")
-                 case .unknownFailure:
-                     print("Unknown failure")
-                 }
              case let .success(success):
                  switch success {
                  case let .trades(trades):
@@ -116,6 +107,15 @@ class ViewController: UIViewController {
                      print(ping)
                  case .empty:
                      print("Empty data")
+                 }
+             case let .failure(failure):
+                 switch failure {
+                 case .networkFailure:
+                     print(failure)
+                 case .invalidData:
+                     print("Invalid data")
+                 case .unknownFailure:
+                     print("Unknown failure")
                  }
              }
          }

--- a/Sources/FinnhubSwift/FinnhubClient.swift
+++ b/Sources/FinnhubSwift/FinnhubClient.swift
@@ -17,11 +17,11 @@ public struct FinnhubClient {
         return resource
     }
 
-    fileprivate static func parseResponse<T>(result: Result<T?, Error>) -> Result<T?, FinnhubWebError> {
+    fileprivate static func parseResponse<T>(result: Result<T?, Error>) -> Result<T, FinnhubWebError> {
         switch result {
         case let .success(data):
-            if let symbols = data {
-                return (.success(symbols))
+            if let parsed = data {
+                return (.success(parsed))
             } else {
                 return (.failure(.invalidData))
             }
@@ -32,7 +32,7 @@ public struct FinnhubClient {
 
     // MARK: Symbols
 
-    public static func symbols(exchange: Exchange, completion: @escaping (Result<[CompanySymbol]?, FinnhubWebError>) -> Void) {
+    public static func symbols(exchange: Exchange, completion: @escaping (Result<[CompanySymbol], FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/symbol?exchange=\(exchange.rawValue)")
         let resource = Resource<[CompanySymbol]>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<[CompanySymbol]?, Error>) in
@@ -42,13 +42,13 @@ public struct FinnhubClient {
 
     // MARK: Market News
 
-    public static func news(category: NewsCategory, completion: @escaping (Result<[MarketNews]?, FinnhubWebError>) -> Void) {
+    public static func news(category: NewsCategory, completion: @escaping (Result<[MarketNews], FinnhubWebError>) -> Void) {
         newsWithMinId(category: category, minId: 0, completion: { result in
             completion(result)
         })
     }
 
-    public static func newsWithMinId(category: NewsCategory, minId: Int = 0, completion: @escaping (Result<[MarketNews]?, FinnhubWebError>) -> Void) {
+    public static func newsWithMinId(category: NewsCategory, minId: Int = 0, completion: @escaping (Result<[MarketNews], FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/news?category=\(category.rawValue)?minId=\(minId)")
         let resource = Resource<[MarketNews]>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<[MarketNews]?, Error>) in
@@ -58,7 +58,7 @@ public struct FinnhubClient {
 
     // MARK: News Sentiment
 
-    public static func newsSentiment(symbol: String, completion: @escaping (Result<NewsSentiment?, FinnhubWebError>) -> Void) {
+    public static func newsSentiment(symbol: String, completion: @escaping (Result<NewsSentiment, FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/news-sentiment?symbol=\(symbol)")
         let resource = Resource<NewsSentiment>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<NewsSentiment?, Error>) in
@@ -68,7 +68,7 @@ public struct FinnhubClient {
 
     // MARK: Peers
 
-    public static func peers(symbol: String, completion: @escaping (Result<[String]?, FinnhubWebError>) -> Void) {
+    public static func peers(symbol: String, completion: @escaping (Result<[String], FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/peers?symbol=\(symbol)")
         let resource = Resource<[String]>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<[String]?, Error>) in
@@ -78,7 +78,7 @@ public struct FinnhubClient {
 
     // MARK: Recommendations
 
-    public static func recommendations(symbol: String, completion: @escaping (Result<[Recommendation]?, FinnhubWebError>) -> Void) {
+    public static func recommendations(symbol: String, completion: @escaping (Result<[Recommendation], FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/recommendation?symbol=\(symbol)")
         let resource = Resource<[Recommendation]>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<[Recommendation]?, Error>) in
@@ -88,7 +88,7 @@ public struct FinnhubClient {
 
     // MARK: Price Target
 
-    public static func priceTarget(symbol: String, completion: @escaping (Result<PriceTarget?, FinnhubWebError>) -> Void) {
+    public static func priceTarget(symbol: String, completion: @escaping (Result<PriceTarget, FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/price-target?symbol=\(symbol)")
         let resource = Resource<PriceTarget>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<PriceTarget?, Error>) in
@@ -98,7 +98,7 @@ public struct FinnhubClient {
 
     // MARK: Company Profile 2
 
-    public static func companyProfile2(symbol: String, completion: @escaping (Result<CompanyProfile?, FinnhubWebError>) -> Void) {
+    public static func companyProfile2(symbol: String, completion: @escaping (Result<CompanyProfile, FinnhubWebError>) -> Void) {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/profile2?symbol=\(symbol)")
         let resource = Resource<CompanyProfile>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<CompanyProfile?, Error>) in


### PR DESCRIPTION
The parseResponse function already ensures that we don't return an optional
success response. Therefore, we don't need our completion blocks to remain
optional. This cleans up callers of our API from needing to do unnecessary
unwrapping.