### PR TITLE
1.06, More endpoint support

### DIFF
--- a/Sources/FinnhubSwift/FinnhubClient.swift
+++ b/Sources/FinnhubSwift/FinnhubClient.swift
@@ -30,6 +30,14 @@ public struct FinnhubClient {
         }
     }
 
+    fileprivate static func validateDateString(date: String) {
+        let dateFormatterGet = DateFormatter()
+        dateFormatterGet.dateFormat = "yyyy-MM-dd"
+        if dateFormatterGet.date(from: date) == nil {
+            fatalError("Invalid date string: \(date)")
+        }
+    }
+
     // MARK: Symbols
 
     public static func symbols(exchange: Exchange, completion: @escaping (Result<[CompanySymbol], FinnhubWebError>) -> Void) {
@@ -102,6 +110,69 @@ public struct FinnhubClient {
         let url = SafeURL.path("\(Constants.BASE_URL)/stock/profile2?symbol=\(symbol)")
         let resource = Resource<CompanyProfile>(get: url, headers: headers())
         URLSession.shared.load(resource) { (result: Result<CompanyProfile?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: Split
+
+    // "to" and "from" parameters should be formatted as YYYY-MM-DD
+    public static func split(symbol: String, from: String, to: String, completion: @escaping (Result<[Split], FinnhubWebError>) -> Void) {
+        validateDateString(date: from)
+        validateDateString(date: to)
+        let url = SafeURL.path("\(Constants.BASE_URL)/stock/split?symbol=\(symbol)&from=\(from)&to\(to)")
+        let resource = Resource<[Split]>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<[Split]?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: Country
+
+    public static func country(symbol _: String, completion: @escaping (Result<[Country], FinnhubWebError>) -> Void) {
+        let url = SafeURL.path("\(Constants.BASE_URL)/country")
+        let resource = Resource<[Country]>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<[Country]?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: Economic Calendar
+
+    public static func economicCalendar(symbol _: String, completion: @escaping (Result<EconomicCalendar, FinnhubWebError>) -> Void) {
+        let url = SafeURL.path("\(Constants.BASE_URL)/calendar/economic")
+        let resource = Resource<EconomicCalendar>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<EconomicCalendar?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: FDA Committee Calendar
+
+    public static func fdaAdvisoryCommitteeCalendar(symbol _: String, completion: @escaping (Result<[FDACalendarEvent], FinnhubWebError>) -> Void) {
+        let url = SafeURL.path("\(Constants.BASE_URL)/fda-advisory-committee-calendar")
+        let resource = Resource<[FDACalendarEvent]>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<[FDACalendarEvent]?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: Covid Case Count
+
+    public static func covidCasesUS(symbol _: String, completion: @escaping (Result<[CovidCaseCount], FinnhubWebError>) -> Void) {
+        let url = SafeURL.path("\(Constants.BASE_URL)/covid/us")
+        let resource = Resource<[CovidCaseCount]>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<[CovidCaseCount]?, Error>) in
+            completion(FinnhubClient.parseResponse(result: result))
+        }
+    }
+
+    // MARK: Aggregate Indicators
+
+    public static func aggregateIndicators(symbol: String, resolution: Resolution, completion: @escaping (Result<AggregateIndicators, FinnhubWebError>) -> Void) {
+        let url = SafeURL.path("\(Constants.BASE_URL)/scan/technical-indicator?symbol=\(symbol)&resolution=\(resolution.rawValue)")
+        let resource = Resource<AggregateIndicators>(get: url, headers: headers())
+        URLSession.shared.load(resource) { (result: Result<AggregateIndicators?, Error>) in
             completion(FinnhubClient.parseResponse(result: result))
         }
     }

--- a/Sources/FinnhubSwift/Models/AggregateIndicators.swift
+++ b/Sources/FinnhubSwift/Models/AggregateIndicators.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct AggregateIndicators: Codable, Equatable {
+    var technicalAnalysis: TechnicalAnalysis
+    var trend: Trend
+
+    public static func == (lhs: AggregateIndicators, rhs: AggregateIndicators) -> Bool {
+        return lhs.technicalAnalysis == rhs.technicalAnalysis &&
+            lhs.trend == rhs.trend
+    }
+}
+
+public struct TechnicalAnalysis: Codable, Equatable {
+    var count: TechnicalAnalysisCount
+    var signal: String
+
+    public static func == (lhs: TechnicalAnalysis, rhs: TechnicalAnalysis) -> Bool {
+        return lhs.count == rhs.count &&
+            lhs.signal == rhs.signal
+    }
+}
+
+public struct TechnicalAnalysisCount: Codable, Equatable {
+    var buy: Int
+    var neutral: Int
+    var sell: Int
+
+    public static func == (lhs: TechnicalAnalysisCount, rhs: TechnicalAnalysisCount) -> Bool {
+        return lhs.buy == rhs.buy &&
+            lhs.neutral == rhs.neutral &&
+            lhs.sell == rhs.sell
+    }
+}
+
+public struct Trend: Codable, Equatable {
+    var adx: Double
+    var trending: Bool
+
+    public static func == (lhs: Trend, rhs: Trend) -> Bool {
+        return lhs.adx == rhs.adx &&
+            lhs.trending == rhs.trending
+    }
+}

--- a/Sources/FinnhubSwift/Models/Country.swift
+++ b/Sources/FinnhubSwift/Models/Country.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct Country: Codable, Equatable {
+    var code2: String
+    var code3: String
+    var codeNo: Int
+    var country: String
+    var currency: String
+    var currencyCode: String
+
+    public static func == (lhs: Country, rhs: Country) -> Bool {
+        return lhs.codeNo == rhs.codeNo
+    }
+}

--- a/Sources/FinnhubSwift/Models/CovidCaseCount.swift
+++ b/Sources/FinnhubSwift/Models/CovidCaseCount.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct CovidCaseCount: Codable, Equatable {
+    var usState: String
+    var caseCount: Int
+    var death: Int
+    var updated: String
+
+    enum CodingKeys: String, CodingKey {
+        case usState = "state"
+        case caseCount = "case"
+        case death
+        case updated
+    }
+
+    public static func == (lhs: CovidCaseCount, rhs: CovidCaseCount) -> Bool {
+        return lhs.usState == rhs.usState &&
+            lhs.caseCount == rhs.caseCount &&
+            lhs.death == rhs.death &&
+            lhs.updated == rhs.updated
+    }
+}

--- a/Sources/FinnhubSwift/Models/EconomicCalendar.swift
+++ b/Sources/FinnhubSwift/Models/EconomicCalendar.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct EconomicEvent: Codable, Equatable {
+    var actual: Double
+    var country: String
+    var estimate: Double
+    var event: String
+    var impact: String
+    var prev: Int
+    var time: String
+    var unit: String
+
+    public static func == (lhs: EconomicEvent, rhs: EconomicEvent) -> Bool {
+        return lhs.actual == rhs.actual &&
+            lhs.country == rhs.country &&
+            lhs.estimate == rhs.estimate &&
+            lhs.event == rhs.event &&
+            lhs.impact == rhs.impact &&
+            lhs.prev == rhs.prev &&
+            lhs.time == rhs.time &&
+            lhs.unit == rhs.unit
+    }
+}
+
+public struct EconomicCalendar: Codable, Equatable {
+    var economicCalendar: [EconomicEvent]
+
+    public static func == (lhs: EconomicCalendar, rhs: EconomicCalendar) -> Bool {
+        return lhs.economicCalendar == rhs.economicCalendar
+    }
+}

--- a/Sources/FinnhubSwift/Models/FDACalendarEvent.swift
+++ b/Sources/FinnhubSwift/Models/FDACalendarEvent.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct FDACalendarEvent: Codable, Equatable {
+    var fromDate: String
+    var toDate: String
+    var eventDescription: String
+    var url: String
+
+    public static func == (lhs: FDACalendarEvent, rhs: FDACalendarEvent) -> Bool {
+        return lhs.fromDate == rhs.fromDate &&
+            lhs.toDate == rhs.toDate &&
+            lhs.eventDescription == rhs.eventDescription &&
+            lhs.url == rhs.url
+    }
+}

--- a/Sources/FinnhubSwift/Models/Resolution.swift
+++ b/Sources/FinnhubSwift/Models/Resolution.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public enum Resolution: String {
+    case month = "M"
+    case week = "W"
+    case day = "D"
+    case minutes60 = "60"
+    case minutes30 = "30"
+    case minutes15 = "15"
+    case minutes5 = "5"
+    case minutes1 = "1"
+}

--- a/Sources/FinnhubSwift/Models/Split.swift
+++ b/Sources/FinnhubSwift/Models/Split.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Split: Codable, Equatable {
+    var symbol: String
+    var date: String
+    var fromFactor: Int
+    var toFactor: Int
+
+    public static func == (lhs: Split, rhs: Split) -> Bool {
+        return lhs.symbol == rhs.symbol &&
+            lhs.date == rhs.date &&
+            lhs.fromFactor == rhs.fromFactor &&
+            lhs.toFactor == rhs.toFactor
+    }
+}

--- a/Tests/FinnhubSwiftTests/SafeURLTests.swift
+++ b/Tests/FinnhubSwiftTests/SafeURLTests.swift
@@ -3,7 +3,12 @@ import XCTest
 
 final class SafeURLTests: XCTestCase {
     func testThatItCreatesSafeURLs() {
-        let strings = ["https://google.com", "https://finnhub.io", "https://finnhub.io/api/v1"]
+        let strings = [
+            "https://google.com",
+            "https://finnhub.io",
+            "https://finnhub.io/api/v1",
+            "https://finnhub.io/api/v1/news?category=general&token=123",
+        ]
         for string in strings {
             testThatItCreatesSafeURL(string: string)
         }


### PR DESCRIPTION
New endpoints:
- Aggregate indicators
- Countries
- Covid cases
- Economic calendar
- FDA committee calendar
- Splits

Other changes:
- More URL tests
- Param enums