### PR TITLE
Better test coverage, marketnews.summary

### DIFF
--- a/Sources/FinnhubSwift/Models/LiveResponse.swift
+++ b/Sources/FinnhubSwift/Models/LiveResponse.swift
@@ -10,16 +10,16 @@ public enum LiveResponseType: String {
     case ping
 }
 
-public struct LiveTrades: Codable, LiveResponse, Equatable, Hashable {
+public struct LiveTrades: LiveResponse, Mappable {
     public var data: [Trade]
     public var type: String
 }
 
-public struct LiveNews: Codable, LiveResponse, Equatable, Hashable {
+public struct LiveNews: LiveResponse, Mappable {
     public var data: [MarketNews]
     public var type: String
 }
 
-public struct LivePing: Codable, LiveResponse, Equatable {
+public struct LivePing: LiveResponse, Mappable {
     public var type: String
 }

--- a/Sources/FinnhubSwift/Models/MarketNews.swift
+++ b/Sources/FinnhubSwift/Models/MarketNews.swift
@@ -7,6 +7,8 @@ public struct MarketNews: Mappable {
     public var id: Int
     public var image: String
     public var related: String
+    // TODO: We want this parameter, but need special encoding
+//    public var summary: String
     public var source: String
     public var url: String
 

--- a/Sources/FinnhubSwift/Models/MarketNews.swift
+++ b/Sources/FinnhubSwift/Models/MarketNews.swift
@@ -8,7 +8,6 @@ public struct MarketNews: Mappable {
     public var image: String
     public var related: String
     public var source: String
-    public var summary: String
     public var url: String
 
     public static func == (lhs: MarketNews, rhs: MarketNews) -> Bool {

--- a/Tests/FinnhubSwiftTests/FDACalendarEventTests.swift
+++ b/Tests/FinnhubSwiftTests/FDACalendarEventTests.swift
@@ -1,0 +1,92 @@
+@testable import FinnhubSwift
+import XCTest
+
+final class FDAEventCalendarTests: XCTestCase {
+    func testsThatItCreatesFDAEventCalendars() {
+        let notJsonString = Data("Hello".utf8)
+        let wrong = Data("""
+            [
+              "AAPL",
+              "EMC",
+              "HPQ",
+              "DELL",
+              "WDC",
+              "HPE",
+              "NTAP",
+              "CPQ",
+              "SNDK",
+              "SEG"
+            ]
+        """.utf8)
+        let partial = Data("""
+            [
+              {
+                "fromDate": "2016-01-11 19:00:00",
+                "toDate": "2016-01-11 19:00:00",
+              }
+            ]
+        """.utf8)
+        let one = Data("""
+            [
+              {
+                "fromDate": "2016-01-11 19:00:00",
+                "toDate": "2016-01-11 19:00:00",
+                "eventDescription": "January 12, 2016: Meeting of the Psychopharmacologic Drugs Advisory Committee Meeting Announcement - 01/11/2016 - 01/11/2016",
+                "url": "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-12-2016-meeting-psychopharmacologic-drugs-advisory-committee-meeting-announcement-01112016"
+              }
+            ]
+        """.utf8)
+        let many = Data("""
+             [
+               {
+                 "fromDate": "2016-01-11 19:00:00",
+                 "toDate": "2016-01-11 19:00:00",
+                 "eventDescription": "January 12, 2016: Meeting of the Psychopharmacologic Drugs Advisory Committee Meeting Announcement - 01/11/2016 - 01/11/2016",
+                 "url": "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-12-2016-meeting-psychopharmacologic-drugs-advisory-committee-meeting-announcement-01112016"
+               },
+               {
+                 "fromDate": "2016-01-14 13:00:00",
+                 "toDate": "2016-01-14 17:00:00",
+                 "eventDescription": "January 14, 2016: Vaccines and Related Biological Products Advisory Committee Meeting Announcement - 01/14/2016 - 01/14/2016",
+                 "url": "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-14-2016-vaccines-and-related-biological-products-advisory-committee-meeting-announcement"
+               }
+             ]
+        """.utf8)
+
+        let data: [CodableTester] = [
+            CodableTester(payload: many, expect: true),
+            CodableTester(payload: one, expect: true),
+            CodableTester(payload: partial, expect: false),
+            CodableTester(payload: wrong, expect: false),
+            CodableTester(payload: notJsonString, expect: false),
+        ]
+
+        for datum in data {
+            testsThatItCreatesFDAEventCalendar(data: datum)
+        }
+    }
+
+    func testsThatItCreatesFDAEventCalendar(data: CodableTester) {
+        let country = try? JSONDecoder().decode([FDACalendarEvent].self, from: data.payload)
+        if data.expect {
+            XCTAssertNotNil(country)
+        } else {
+            XCTAssertNil(country)
+        }
+    }
+
+    func testThatEquatable() {
+        let fixture1 = FDACalendarEvent(fromDate: "2016-01-14 13:00:00", toDate: "2016-01-14 17:00:00", eventDescription: "January 14, 2016: Vaccines and Related Biological Products Advisory Committee Meeting Announcement - 01/14/2016 - 01/14/2016", url: "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-14-2016-vaccines-and-related-biological-products-advisory-committee-meeting-announcement")
+        let fixture2 = FDACalendarEvent(fromDate: "2016-01-14 13:00:00", toDate: "2016-01-14 17:00:00", eventDescription: "January 14, 2016: Vaccines and Related Biological Products Advisory Committee Meeting Announcement - 01/14/2016 - 01/14/2016", url: "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-14-2016-vaccines-and-related-biological-products-advisory-committee-meeting-announcement")
+        XCTAssertEqual(fixture1, fixture2)
+    }
+
+    func testThatHashable() {
+        let fixture1 = FDACalendarEvent(fromDate: "2016-01-14 13:00:00", toDate: "2016-01-14 17:00:00", eventDescription: "January 14, 2016: Vaccines and Related Biological Products Advisory Committee Meeting Announcement - 01/14/2016 - 01/14/2016", url: "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-14-2016-vaccines-and-related-biological-products-advisory-committee-meeting-announcement")
+        let fixture2 = FDACalendarEvent(fromDate: "2016-01-14 13:00:00", toDate: "2016-01-14 17:00:00", eventDescription: "YUKON CLASSIC", url: "https://www.fda.gov/advisory-committees/advisory-committee-calendar/january-14-2016-vaccines-and-related-biological-products-advisory-committee-meeting-announcement")
+        let fixtures: Set<FDACalendarEvent> = [fixture1, fixture2]
+
+        XCTAssertTrue(fixtures.contains(fixture1))
+        XCTAssertTrue(fixtures.contains(fixture2))
+    }
+}

--- a/Tests/FinnhubSwiftTests/FinnhubLiveClientTests.swift
+++ b/Tests/FinnhubSwiftTests/FinnhubLiveClientTests.swift
@@ -72,7 +72,7 @@ final class FinnhubLiveClientTests: XCTestCase {
             }],"type":"news"}
         """
         let result = FinnhubLiveClient.shared.parseLiveText(response)
-        let fixture = LiveNews(data: [MarketNews(category: "technology", datetime: 1_596_589_501, headline: "Square surges after reporting 64% jump in revenue, more customers using Cash App", id: 5_085_164, image: "https://image.cnbcfm.com/api/v1/image/105569283-1542050972462rts25mct.jpg?v=1542051069", related: "", source: "CNBC", summary: "Shares of Square soared on Tuesday evening after posting better-than-expected quarterly results and strong growth in its consumer payments app.", url: "https://www.cnbc.com/2020/08/04/square-sq-earnings-q2-2020.html")], type: LiveResponseType.news.rawValue)
+        let fixture = LiveNews(data: [MarketNews(category: "technology", datetime: 1_596_589_501, headline: "Square surges after reporting 64% jump in revenue, more customers using Cash App", id: 5_085_164, image: "https://image.cnbcfm.com/api/v1/image/105569283-1542050972462rts25mct.jpg?v=1542051069", related: "", source: "CNBC", url: "https://www.cnbc.com/2020/08/04/square-sq-earnings-q2-2020.html")], type: LiveResponseType.news.rawValue)
         guard case let .success(success) = result else {
             XCTFail("Expected .success")
             return

--- a/Tests/FinnhubSwiftTests/MarketNewsTests.swift
+++ b/Tests/FinnhubSwiftTests/MarketNewsTests.swift
@@ -1,0 +1,113 @@
+@testable import FinnhubSwift
+import XCTest
+
+final class MarketNewsTests: XCTestCase {
+    func testsThatItCreatesMarketNewsEntries() {
+        let notJsonString = Data("Hello".utf8)
+        let wrong = Data("""
+            [
+              "AAPL",
+              "EMC",
+              "HPQ",
+              "DELL",
+              "WDC",
+              "HPE",
+              "NTAP",
+              "CPQ",
+              "SNDK",
+              "SEG"
+            ]
+        """.utf8)
+        let partial = Data("""
+            [
+              {
+                "category": "technology",
+                "datetime": 1596589501,
+
+                "image": "https://image.cnbcfm.com/api/v1/image/105569283-1542050972462rts25mct.jpg?v=1542051069",
+              }
+            ]
+        """.utf8)
+        let one = Data("""
+            [
+              {
+                "category": "technology",
+                "datetime": 1596589501,
+                "headline": "Square surges after reporting 64% jump in revenue, more customers using Cash App",
+                "id": 5085164,
+                "image": "https://image.cnbcfm.com/api/v1/image/105569283-1542050972462rts25mct.jpg?v=1542051069",
+                "related": "",
+                "source": "CNBC",
+                "url": "https://www.cnbc.com/2020/08/04/square-sq-earnings-q2-2020.html"
+              }
+            ]
+        """.utf8)
+        let many = Data("""
+            [
+              {
+                "category": "technology",
+                "datetime": 1596589501,
+                "headline": "Square surges after reporting 64% jump in revenue, more customers using Cash App",
+                "id": 5085164,
+                "image": "https://image.cnbcfm.com/api/v1/image/105569283-1542050972462rts25mct.jpg?v=1542051069",
+                "related": "",
+                "source": "CNBC",
+                "url": "https://www.cnbc.com/2020/08/04/square-sq-earnings-q2-2020.html"
+              },
+            {
+                "category": "business",
+                "datetime": 1596588232,
+                "headline": "B&G Foods CEO expects pantry demand to hold up post-pandemic",
+                "id": 5085113,
+                "image": "https://image.cnbcfm.com/api/v1/image/106629991-1595532157669-gettyimages-1221952946-362857076_1-5.jpeg?v=1595532242",
+                "related": "",
+                "source": "CNBC",
+                "url": "https://www.cnbc.com/2020/08/04/bg-foods-ceo-expects-pantry-demand-to-hold-up-post-pandemic.html"
+              },
+            ]
+        """.utf8)
+
+        let data: [CodableTester] = [
+            CodableTester(payload: many, expect: true),
+            CodableTester(payload: one, expect: true),
+            CodableTester(payload: partial, expect: false),
+            CodableTester(payload: wrong, expect: false),
+            CodableTester(payload: notJsonString, expect: false),
+        ]
+
+        for datum in data {
+            testsThatItCreatesMarketNews(data: datum)
+        }
+    }
+
+    func testsThatItCreatesMarketNews(data: CodableTester) {
+        let country = try? JSONDecoder().decode([MarketNews].self, from: data.payload)
+        if data.expect {
+            print(data)
+            XCTAssertNotNil(country)
+        } else {
+            XCTAssertNil(country)
+        }
+    }
+
+    func testThatEquatable() {
+        let fixture1 = MarketNews(category: "technology", datetime: 156_934_523_432, headline: "B&G Foods", id: 5_085_113, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        let fixture2 = MarketNews(category: "technology", datetime: 156_934_523_432, headline: "B&G Foods", id: 5_085_113, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        XCTAssertEqual(fixture1, fixture2)
+    }
+
+    func testThatEquatableById() {
+        let fixture1 = MarketNews(category: "technology", datetime: 156_934_523_432, headline: "B&G Foods", id: 5_085_113, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        let fixture2 = MarketNews(category: "news", datetime: 2, headline: "", id: 5_085_113, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        XCTAssertEqual(fixture1, fixture2)
+    }
+
+    func testThatHashable() {
+        let fixture1 = MarketNews(category: "technology", datetime: 156_934_523_432, headline: "B&G Foods", id: 5_085_113, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        let fixture2 = MarketNews(category: "news", datetime: 2, headline: "", id: 5_085_111, image: "https://image.com", related: "", source: "CNBC", url: "https://cnbc.com")
+        let fixtures: Set<MarketNews> = [fixture1, fixture2]
+
+        XCTAssertTrue(fixtures.contains(fixture1))
+        XCTAssertTrue(fixtures.contains(fixture2))
+    }
+}

--- a/Tests/FinnhubSwiftTests/NewsSentimentTests.swift
+++ b/Tests/FinnhubSwiftTests/NewsSentimentTests.swift
@@ -1,0 +1,87 @@
+@testable import FinnhubSwift
+import XCTest
+
+final class NewsSentimentTests: XCTestCase {
+    func testsThatItCreatesNewsEntries() {
+        let notJsonString = Data("Hello".utf8)
+        let wrong = Data("""
+            [
+              "AAPL",
+              "EMC",
+              "HPQ",
+              "DELL",
+              "WDC",
+              "HPE",
+              "NTAP",
+              "CPQ",
+              "SNDK",
+              "SEG"
+            ]
+        """.utf8)
+        let partial = Data("""
+            {
+              "buzz": {
+                "articlesInLastWeek": 20,
+                "buzz": 0.8888,
+                "weeklyAverage": 22.5
+              },
+              "companyNewsScore": 0.9166,
+              "sectorAverageBullishPercent": 0.6482,
+              "symbol": "V"
+            }
+        """.utf8)
+        let one = Data("""
+            {
+              "buzz": {
+                "articlesInLastWeek": 20,
+                "buzz": 0.8888,
+                "weeklyAverage": 22.5
+              },
+              "companyNewsScore": 0.9166,
+              "sectorAverageBullishPercent": 0.6482,
+              "sectorAverageNewsScore": 0.5191,
+              "sentiment": {
+                "bearishPercent": 0,
+                "bullishPercent": 1
+              },
+              "symbol": "V"
+            }
+        """.utf8)
+
+        let data: [CodableTester] = [
+            CodableTester(payload: one, expect: true),
+            CodableTester(payload: partial, expect: false),
+            CodableTester(payload: wrong, expect: false),
+            CodableTester(payload: notJsonString, expect: false),
+        ]
+
+        for datum in data {
+            testsThatItCreatesNews(data: datum)
+        }
+    }
+
+    func testsThatItCreatesNews(data: CodableTester) {
+        let country = try? JSONDecoder().decode(NewsSentiment.self, from: data.payload)
+        if data.expect {
+            print(data)
+            XCTAssertNotNil(country)
+        } else {
+            XCTAssertNil(country)
+        }
+    }
+
+    func testThatEquatable() {
+        let fixture1 = NewsSentiment(buzz: Buzz(articlesInLastWeek: 20, buzz: 0.888, weeklyAverage: 22.5), companyNewsScore: 0.9166, sectorAverageBullishPercent: 0.6482, sectorAverageNewsScore: 0.5191, sentiment: Sentiment(bearishPercent: 0, bullishPercent: 1), symbol: "V")
+        let fixture2 = NewsSentiment(buzz: Buzz(articlesInLastWeek: 20, buzz: 0.888, weeklyAverage: 22.5), companyNewsScore: 0.9166, sectorAverageBullishPercent: 0.6482, sectorAverageNewsScore: 0.5191, sentiment: Sentiment(bearishPercent: 0, bullishPercent: 1), symbol: "V")
+        XCTAssertEqual(fixture1, fixture2)
+    }
+
+    func testThatHashable() {
+        let fixture1 = NewsSentiment(buzz: Buzz(articlesInLastWeek: 20, buzz: 0.888, weeklyAverage: 22.5), companyNewsScore: 0.9166, sectorAverageBullishPercent: 0.6482, sectorAverageNewsScore: 0.5191, sentiment: Sentiment(bearishPercent: 0, bullishPercent: 1), symbol: "V")
+        let fixture2 = NewsSentiment(buzz: Buzz(articlesInLastWeek: 20, buzz: 0.887, weeklyAverage: 22.5), companyNewsScore: 0.9166, sectorAverageBullishPercent: 0.6482, sectorAverageNewsScore: 0.5191, sentiment: Sentiment(bearishPercent: 0, bullishPercent: 1), symbol: "V")
+        let fixtures: Set<NewsSentiment> = [fixture1, fixture2]
+
+        XCTAssertTrue(fixtures.contains(fixture1))
+        XCTAssertTrue(fixtures.contains(fixture2))
+    }
+}

--- a/Tests/FinnhubSwiftTests/PriceTarget.swift
+++ b/Tests/FinnhubSwiftTests/PriceTarget.swift
@@ -1,0 +1,87 @@
+@testable import FinnhubSwift
+import XCTest
+
+final class PriceTargetTests: XCTestCase {
+    func testThatItCreatesPriceTargetEntries() {
+        let notJsonString = Data("Hello".utf8)
+        let wrong = Data("""
+            [
+              "AAPL",
+              "EMC",
+              "HPQ",
+              "DELL",
+              "WDC",
+              "HPE",
+              "NTAP",
+              "CPQ",
+              "SNDK",
+              "SEG"
+            ]
+        """.utf8)
+        let partial = Data("""
+            {
+              "lastUpdated": "2019-06-03 00:00:00",
+              "symbol": "NFLX",
+              "targetHigh": 500,
+              "targetLow": 166,
+            }
+        """.utf8)
+        let intTarget = Data("""
+            {
+              "lastUpdated": "2019-06-03 00:00:00",
+              "symbol": "NFLX",
+              "targetHigh": 500,
+              "targetLow": 166,
+              "targetMean": 387.03,
+              "targetMedian": 417.5
+            }
+        """.utf8)
+        let doubleTarget = Data("""
+            {
+                "lastUpdated":"2020-10-14 00:00:00",
+                "symbol":"AAPL",
+                "targetHigh":150,
+                "targetLow":48.86,
+                "targetMean":119.37,
+                "targetMedian":125,
+            }
+        """.utf8)
+
+        let data: [CodableTester] = [
+            CodableTester(payload: intTarget, expect: true),
+            CodableTester(payload: doubleTarget, expect: true),
+            CodableTester(payload: partial, expect: false),
+            CodableTester(payload: wrong, expect: false),
+            CodableTester(payload: notJsonString, expect: false),
+        ]
+
+        for datum in data {
+            testThatItCreates(data: datum)
+        }
+    }
+
+    func testThatItCreates(data: CodableTester) {
+        let country = try? JSONDecoder().decode(PriceTarget.self, from: data.payload)
+        if data.expect {
+            print(data)
+            XCTAssertNotNil(country)
+        } else {
+            XCTAssertNil(country)
+        }
+    }
+
+    func testThatEquatable() {
+        let fixture1 = PriceTarget(lastUpdated: "2019", symbol: "NFLX", targetHigh: 500, targetLow: 166, targetMean: 387.03, targetMedian: 417.5)
+        let fixture2 = PriceTarget(lastUpdated: "2019", symbol: "NFLX", targetHigh: 500, targetLow: 166, targetMean: 387.03, targetMedian: 417.5)
+        XCTAssertEqual(fixture1, fixture2)
+    }
+
+    func testThatHashable() {
+        let fixture1 = PriceTarget(lastUpdated: "2019", symbol: "NFLX", targetHigh: 500, targetLow: 166, targetMean: 387.03, targetMedian: 417.5)
+        let fixture2 = PriceTarget(lastUpdated: "2018", symbol: "NFLX", targetHigh: 500, targetLow: 166, targetMean: 387.03, targetMedian: 417.5)
+        let fixtures: Set<PriceTarget> = [fixture1, fixture2]
+
+        XCTAssertTrue(fixtures.contains(fixture1))
+        XCTAssertTrue(fixtures.contains(fixture2))
+    }
+}


### PR DESCRIPTION
Eliminate the summary property from market news until I figure out how to do
custom encoding for a single escaped quotes json string. I believe these should
be double escaped for valid JSON, so I'll need to do a dive to figure out how to
work around it.