### PR TITLE
Abstract any FinnhubSwift model refs from View

### DIFF
--- a/Examples/Stocks/SymbolsCollectionView.swift
+++ b/Examples/Stocks/SymbolsCollectionView.swift
@@ -6,7 +6,6 @@ class SymbolsCollectionView: UICollectionView {
         let layout = UICollectionViewCompositionalLayout.list(using: configuration)
 
         super.init(frame: frame, collectionViewLayout: layout)
-
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .systemGroupedBackground
     }

--- a/Examples/Stocks/SymbolsDataSource.swift
+++ b/Examples/Stocks/SymbolsDataSource.swift
@@ -1,16 +1,15 @@
-import FinnhubSwift
 import UIKit
 
 enum Section: CaseIterable {
     case main
 }
 
-class SymbolsDataSource: UICollectionViewDiffableDataSource<Section, CompanySymbol> {
+class SymbolsDataSource: UICollectionViewDiffableDataSource<Section, SymbolViewModel> {
     init(ownedCollectionView: UICollectionView) {
-        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, CompanySymbol> { cell, _, symbol in
+        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, SymbolViewModel> { cell, _, symbol in
             var contentConfiguration = UIListContentConfiguration.cell()
-            contentConfiguration.text = symbol.description
-            contentConfiguration.secondaryText = symbol.symbol
+            contentConfiguration.text = symbol.text
+            contentConfiguration.secondaryText = symbol.secondaryText
             cell.contentConfiguration = contentConfiguration
             cell.accessories = [.disclosureIndicator()]
         }
@@ -20,8 +19,8 @@ class SymbolsDataSource: UICollectionViewDiffableDataSource<Section, CompanySymb
         }
     }
 
-    func update(_ newSymbols: [CompanySymbol]) {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, CompanySymbol>()
+    func update(_ newSymbols: [SymbolViewModel]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, SymbolViewModel>()
         snapshot.appendSections([.main])
         snapshot.appendItems(newSymbols)
         apply(snapshot, animatingDifferences: true)

--- a/Examples/Stocks/SymbolsViewController.swift
+++ b/Examples/Stocks/SymbolsViewController.swift
@@ -1,5 +1,4 @@
 import Combine
-import FinnhubSwift
 import UIKit
 
 class SymbolsViewController: UIViewController {
@@ -25,7 +24,7 @@ class SymbolsViewController: UIViewController {
     }
 
     func configureNavItem() {
-        navigationItem.title = "Stocks, NASDAQ & NYSE"
+        navigationItem.title = "Stocks"
         navigationItem.largeTitleDisplayMode = .always
     }
 
@@ -73,10 +72,8 @@ class SymbolsViewController: UIViewController {
         }
 
         loadingSubscriber = symbolsViewModel.$loading.sink(receiveValue: { [weak self] loading in
-            if loading == false {
-                DispatchQueue.main.async {
-                    self?.refreshControl.endRefreshing()
-                }
+            DispatchQueue.main.async {
+                loading ? self?.refreshControl.beginRefreshing() : self?.refreshControl.endRefreshing()
             }
         })
     }
@@ -88,7 +85,7 @@ class SymbolsViewController: UIViewController {
 
 extension SymbolsViewController: UISearchBarDelegate {
     func searchBar(_: UISearchBar, textDidChange searchText: String) {
-        let filteredSymbols = symbolsViewModel.filteredSymbols(with: searchText).sorted { $0.displaySymbol < $1.displaySymbol }
+        let filteredSymbols = symbolsViewModel.filteredSymbols(with: searchText)
         dataSource.update(filteredSymbols)
     }
 }


### PR DESCRIPTION
Sticking with the established MVVM pattern of the Example app, extract
FinnhubSwift model object references from our collectionView datasource and
viewController. Now only the ViewModel knows about the Model.